### PR TITLE
Update of the rule generator

### DIFF
--- a/RewriteRuleGenerator.php
+++ b/RewriteRuleGenerator.php
@@ -93,16 +93,19 @@ class RewriteRuleGenerator
 		if ($this->_post['desc_comments'])
 			$rule['comment']	= $this->_getComment($line[0], $line[1]);
 
-		if (isset($source['host']) && isset ($target['host'])) {
-			if ($source['host'] != $target['host'] ||
-				($this->_post['always_show_host'] && isset($source['host']))) {
+		if (!isset($source['host'])) $source['host'] = '';
+		if (!isset($target['host'])) $target['host'] = '';
+
+		if ($source['host'] != $target['host'] ||
+			($this->_post['always_show_host'] && isset($source['host']))) {
+			if ($source['host'] !== '')
 				$rule['httphost']	= sprintf(self::HTTP_HOST, quotemeta($source['host']));
-				$prefix				= $target['scheme'] . '://' . $target['host'] . '/';
-			} else {
-				$type				= 4;
-				$prefix				= '/';
-			}
+			$prefix				= $target['scheme'] . '://' . $target['host'] . '/';
+		} else {
+			$type				= 4;
+			$prefix				= '/';
 		}
+
 
 		if (count($queries) > 0 && strlen($queries[0])) {
 			$type = ($type === 3) ? 1 : 2;

--- a/RewriteRuleGenerator.php
+++ b/RewriteRuleGenerator.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * RewriteRule Generator
+ *
+ * @license MIT
+ * @author Jesse G. Donat <donatj@gmail.com> http://donatstudios.com
+ * @author Anton J.P. Evers <ajpevers@gmail.com>
+ *
+ * Assumes a form with these elements:
+ * tabbed_rewrites	string			tab separated string, see setDemoData()
+ * type				301|Rewrite		rewrite method
+ * desc_comments	[1]				show comments in output
+ * always_show_host	[1]				use HTTP_HOST on same-domain rewrites
+ */
+class RewriteRuleGenerator
+{
+	// Strings used for building output
+	const HTTP_HOST		= 'RewriteCond %%{HTTP_HOST} ^%s$';
+	const QUERY_STRING	= 'RewriteCond %%{QUERY_STRING} (^|&)%s($|&)';
+	const RULE_301		= 'RewriteRule ^%s$ %s%s?%s [L,R=301]';
+	const RULE_REWRITE	= 'RewriteRule ^%s$ %s%s?%s&%%{QUERY_STRING}';
+	const COMMENT		= '# %s --- %s => %s';
+	const ERROR			= '# MALFORMED LINE SKIPPED: %s';
+
+	// Private variables
+	protected $_post;
+	protected $_lines = array();
+	protected $_rules;
+	protected $_ruleType;
+
+	/**
+	 * Build mod_rewrite rules from a tab separated file with source and
+	 * destination url's.
+	 *
+	 * @return bool|string
+	 */
+	public function getRules()
+	{
+		if (!$this->_getPost())
+			return false;
+		$this->_setLines();
+		$this->_setMethod();
+		foreach ($this->_lines as $line) {
+			if ($this->_isMalformed($line))
+				continue;
+			$this->_buildRule($line);
+		}
+		$this->_sortRules();
+		return $this->_rules;
+	}
+
+	/**
+	 * Load demo data into the $_POST to display on a normal page load.
+	 */
+	public function setDemoData()
+	{
+		$_POST['desc_comments'] = 1;
+		$_POST['tabbed_rewrites'] =
+			"http://www.test.com/test.html	http://www.test.com/spiders.html" .
+			PHP_EOL .
+			"http://www.test.com/faq.html?faq=13&layout=bob	http://www.test2.com/faqs.html" .
+			PHP_EOL .
+			"text/faq.html?faq=20	helpdesk/kb.php";
+	}
+
+	/**
+	 * Build a mod_rewrite rule from a source and target array. The result is
+	 * saved in the $this->_rules array, grouped by type.
+	 *
+	 * These types are:
+	 * - 0: comment
+	 * - 1: a rule, a host and query string(s)
+	 * - 2: a rule and query string(s) no host
+	 * - 3: a rule, a host, no query string
+	 * - 4: just a rule, no host, no query string
+	 *
+	 * Rules will appear in the output in this order. This way a rule without
+	 * query strings cannot overrule the same rule with query strings.
+	 *
+	 * Rules with the most query strings will be placed over those with less
+	 * query strings
+	 *
+	 * @param $line
+	 */
+	protected function _buildRule($line)
+	{
+		$source		= parse_url($line[0]);
+		$target		= parse_url($line[1]);
+		$queries 	= explode('&', $source['query']);
+		$type		= 3;
+		$rule		= array();
+
+		if ($this->_post['desc_comments'])
+			$rule['comment']	= $this->_getComment($line[0], $line[1]);
+
+		if ($source['host'] != $target['host'] ||
+			($this->_post['always_show_host'] && isset($source['host']))) {
+			$rule['httphost']	= sprintf(self::HTTP_HOST, quotemeta($source['host']));
+			$prefix				= $target['scheme'] . '://' . $target['host'] . '/';
+		} else {
+			$type				= 4;
+			$prefix				= '/';
+		}
+
+		if ($queries > 0 && strlen($queries[0]))
+			$type = ($type === 3) ? 1 : 2;
+		foreach ($queries as $query) {
+			if (strlen($query) > 0) {
+				$rule['query'][] = sprintf(self::QUERY_STRING, quotemeta($query));
+			}
+		}
+
+		$rule['rule'] = sprintf($this->_ruleType,
+			quotemeta(ltrim($source['path'], '/')), $prefix,
+			ltrim( $target['path'], '/' ), $target['query']);
+
+		$this->_rules[$type][] = $rule;
+	}
+
+	/**
+	 * Sort rules in this order:
+	 * - 0: comment
+	 * - 1: a rule, a host and query string(s)
+	 * - 2: a rule and query string(s) no host
+	 * - 3: a rule, a host, no query string
+	 * - 4: just a rule, no host, no query string
+	 *
+	 * Rules will appear in the output in this order. This way a rule without
+	 * query strings cannot overrule the same rule with query strings.
+	 *
+	 * Rules with the most query strings will be placed over those with less
+	 * query strings
+	 */
+	protected function _sortRules()
+	{
+		ksort($this->_rules);
+		foreach ($this->_rules as &$rule) {
+			usort($rule, array('RewriteRuleGen', 'sortByQueryLen'));
+			foreach ($rule as &$condition) {
+				if (array_key_exists('query', $condition))
+					$condition['query'] = implode(PHP_EOL, $condition['query']);
+				$condition = implode(PHP_EOL, $condition);
+			}
+			$rule = implode(PHP_EOL . PHP_EOL, $rule);
+		}
+		$this->_rules = implode(PHP_EOL . PHP_EOL, $this->_rules);
+	}
+
+	/**
+	 * Retrieve and format the post data for use in this class
+	 *
+	 * @return array|bool
+	 */
+	protected function _getPost()
+	{
+		if (isset($this->_post))
+			return $this->_post;
+		$this->_post = false;
+		if ($_POST && strlen(trim($_POST['tabbed_rewrites'])))
+			$this->_post = array(
+				'always_show_host'	=> (bool)$_POST['always_show_host'],
+				'desc_comments'		=> (bool)$_POST['desc_comments'],
+				'tabbed_rewrites'	=> explode(PHP_EOL, $_POST['tabbed_rewrites']),
+				'type'				=> $_POST['type'],
+			);
+		return $this->_post;
+	}
+
+	/**
+	 * Split the tab separated input string into a multidimensional array with
+	 * source and destination url's
+	 */
+	protected function _setLines()
+	{
+		foreach ($this->_post['tabbed_rewrites'] as $line) {
+			$line = preg_replace('/(\r|\n)+/', '', $line);
+			$this->_lines[] = explode("\t", preg_replace('/(\t| )+/', '	', trim($line)));
+		}
+	}
+
+	/**
+	 * Validate a source and destination line. If the validation fails, a
+	 * comment line is generated that will ALWAYS show in the output.
+	 *
+	 * @param $line
+	 *
+	 * @return bool
+	 */
+	protected function _isMalformed($line)
+	{
+		if ($line[0] === '')
+			return true;
+		if (count($line) != 2) {
+			$this->_rules[0][] = array(
+				'error' => sprintf(
+					self::ERROR, implode(' ', $line)
+				)
+			);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Build a comment string for the source - target comments
+	 *
+	 * @param $source
+	 * @param $target
+	 *
+	 * @return string
+	 */
+	protected function _getComment($source, $target)
+	{
+		return sprintf(self::COMMENT,
+			$_POST['type'],
+			$source,
+			$target);
+	}
+
+	/**
+	 * Define which kind of rule will be used as output template. As if now that
+	 * may be Redirect or 301
+	 *
+	 * @return bool|string
+	 */
+	protected function _setMethod()
+	{
+		switch ($this->_post['type']) {
+			case '301':
+				$this->_ruleType = self::RULE_301;
+				break;
+			case 'Rewrite':
+				$this->_ruleType = self::RULE_REWRITE;
+				break;
+		}
+		return false;
+	}
+
+	/**
+	 * Sort an array based on the length of $array['query']
+	 * This function is used in usort.
+	 *
+	 * @param $a
+	 * @param $b
+	 *
+	 * @return int
+	 */
+	protected function _sortByQueryLen($a, $b) {
+		if (count($a['query']) == count($b['query']))
+			return 0;
+		return (count($a['query']) > count($b['query'])) ? -1 : 1;
+	}
+}

--- a/RewriteRuleGenerator.php
+++ b/RewriteRuleGenerator.php
@@ -115,7 +115,7 @@ class RewriteRuleGenerator
 
 		$rule['rule'] = sprintf($this->_ruleType,
 			quotemeta(ltrim($source['path'], '/')), isset($prefix) ? $prefix : '',
-			ltrim( $target['path'], '/' ), isset($target['query']) ? $target['query'] : '');
+			ltrim( isset($target['path']) ? $target['path'] : '', '/' ), isset($target['query']) ? $target['query'] : '');
 
 		$this->_rules[$type][] = $rule;
 	}
@@ -249,6 +249,9 @@ class RewriteRuleGenerator
 	 * @return int
 	 */
 	protected function _sortByQueryLen($a, $b) {
+		$a['query'] = isset($a['query']) ? $a['query'] : array();
+		$b['query'] = isset($b['query']) ? $b['query'] : array();
+
 		if (count($a['query']) == count($b['query']))
 			return 0;
 		return (count($a['query']) > count($b['query'])) ? -1 : 1;

--- a/index.php
+++ b/index.php
@@ -8,6 +8,15 @@
 *
 */
 
+/**
+ * Sort an array based on the length of $array['query']
+ * This function is used in usort.
+ *
+ * @param $a
+ * @param $b
+ *
+ * @return int
+ */
 function sortByQueryLen($a, $b) {
 	if (count($a['query']) == count($b['query'])) {
 		return 0;

--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@ if( $_POST ) {
 				$rule['0'] = '# '.$_POST['type'].' --- ' . $ab[0] . ' => ' . $ab[1];
 			}
 
-			if( $ab0p['host'] != $ab1p['host'] ) {
+			if( $ab0p['host'] != $ab1p['host'] || ($_POST['always_show_host'] && isset($ab0p['host']))) {
 				$rule['httphost'] = 'RewriteCond %{HTTP_HOST} ^'.quotemeta($ab0p['host']).'$';
 				$type = '3';
 				$prefix = $ab1p['scheme'] . '://' . $ab1p['host'] . '/';
@@ -102,6 +102,7 @@ if( $_POST ) {
 		<option<?php echo $_POST['type'] == 'Rewrite' ? ' selected="selected"' : '' ?>>Rewrite</option>
 	</select>
 	<label><input type="checkbox" name="desc_comments" value="1"<?php echo $_POST['desc_comments'] ? ' checked="checked"' : '' ?> class="comments">Comments</label>
+    <label><input type="checkbox" name="always_show_host" value="1"<?php echo $_POST['always_show_host'] ? ' checked="checked"' : '' ?> class="host">Always add {HTTP_HOST} condition (f.i. multi-domain sites)</label>
 	<br />
 	<textarea cols="100" rows="20" readonly="readonly" class="rewrite-field output"><?php echo htmlentities($rules) ?></textarea><br />
 	<input type="submit" />

--- a/index.php
+++ b/index.php
@@ -10,11 +10,11 @@ if (!$rules = $ruleGen->getRules())
     <textarea cols="100" rows="20" name="tabbed_rewrites" class="rewrite-field tabbed"><?php echo htmlentities($_POST['tabbed_rewrites']) ?></textarea>
 	<br/>
     <select name="type" class="method">
-		<option<?php echo $_POST['type'] == '301' ? ' selected="selected"' : '' ?>>301</option>
-		<option<?php echo $_POST['type'] == 'Rewrite' ? ' selected="selected"' : '' ?>>Rewrite</option>
+		<option<?php echo (isset($_POST['type']) && $_POST['type'] == '301') ? ' selected="selected"' : '' ?>>301</option>
+		<option<?php echo (isset($_POST['type']) && $_POST['type'] == 'Rewrite') ? ' selected="selected"' : '' ?>>Rewrite</option>
     </select>
-    <label><input type="checkbox" name="desc_comments" value="1"<?php echo $_POST['desc_comments'] ? ' checked="checked"' : '' ?> class="comments">Comments</label>
-    <label><input type="checkbox" name="always_show_host" value="1"<?php echo $_POST['always_show_host'] ? ' checked="checked"' : '' ?> class="host">Always add HTTP_HOST (f.i. multi-domain sites)</label>
+    <label><input type="checkbox" name="desc_comments" value="1"<?php echo (isset($_POST['desc_comments']) && $_POST['desc_comments']) ? ' checked="checked"' : '' ?> class="comments">Comments</label>
+    <label><input type="checkbox" name="always_show_host" value="1"<?php echo (isset($_POST['always_show_host']) && $_POST['always_show_host']) ? ' checked="checked"' : '' ?> class="host">Always add HTTP_HOST (f.i. multi-domain sites)</label>
     <br/>
     <textarea cols="100" rows="20" readonly="readonly" class="rewrite-field output"><?php echo htmlentities($rules) ?></textarea><br/>
     <input type="submit"/>

--- a/index.php
+++ b/index.php
@@ -1,109 +1,21 @@
 <?php
+include('RewriteRuleGenerator.php');
 
-/**
-* RewriteRule Generator
-*
-* @license MIT
-* @author Jesse G. Donat <donatj@gmail.com> http://donatstudios.com
-*
-*/
+$ruleGen = new RewriteRuleGenerator();
 
-/**
- * Sort an array based on the length of $array['query']
- * This function is used in usort.
- *
- * @param $a
- * @param $b
- *
- * @return int
- */
-function sortByQueryLen($a, $b) {
-	if (count($a['query']) == count($b['query'])) {
-		return 0;
-	}
-	return (count($a['query']) > count($b['query'])) ? -1 : 1;
-}
-
-if( $_POST ) {
-	$_POST['tabbed_rewrites'] = preg_replace('/(\t| )+/', '	', $_POST['tabbed_rewrites']); // Spacing Cleanup
-	$lines = explode(PHP_EOL, $_POST['tabbed_rewrites'] );
-
-	$rules = array();
-	$i = -1;
-
-	if( strlen(trim($_POST['tabbed_rewrites'])) ) {
-		foreach( $lines as $line ) {
-			$rule = array();
-			$type = 0;
-			$line = trim($line);
-			if( $line == '' ) continue;
-			$i++;
-			$ab = explode("	", $line);
-
-			if( count($ab) != 2 ) {
-				$rule['error'] = '# MALFORMED LINE SKIPPED: ' . $line;
-				$rules[$type][] = $rule;
-				continue;
-			}
-
-			$ab0p = parse_url( trim($ab[0]) );
-			$ab1p = parse_url( trim($ab[1]) );
-
-			if( $_POST['desc_comments'] ) {
-				$rule['0'] = '# '.$_POST['type'].' --- ' . $ab[0] . ' => ' . $ab[1];
-			}
-
-			if( $ab0p['host'] != $ab1p['host'] || ($_POST['always_show_host'] && isset($ab0p['host']))) {
-				$rule['httphost'] = 'RewriteCond %{HTTP_HOST} ^'.quotemeta($ab0p['host']).'$';
-				$type = '3';
-				$prefix = $ab1p['scheme'] . '://' . $ab1p['host'] . '/';
-			}else{
-				$prefix = '/';
-				$type = '4';
-			}
-
-			$ab0pqs = explode('&', $ab0p['query']);
-			if ($ab0pqs > 0 && strlen($ab0pqs[0]))
-				$type = ($type === '3') ? '1' : '2';
-			foreach( $ab0pqs as $qs ) {
-				if( strlen( $qs ) > 0 ) {
-					$rule['query'][] = 'RewriteCond %{QUERY_STRING} (^|&)'. quotemeta($qs) .'($|&)';
-				}
-			}
-
-			$rule['rule'] = 'RewriteRule ^'.quotemeta(ltrim($ab0p['path'],'/')).'$ '.$prefix.ltrim( $ab1p['path'], '/' ).'?'.$ab1p['query'] . ( $_POST['type'] == 'Rewrite' ? '&%{QUERY_STRING}':' [L,R=301]' );
-			$rules[$type][] = $rule;
-		}
-		if ($i !== -1) {
-			ksort($rules);
-			foreach ($rules as &$t) {
-				usort($t, 'sortByQueryLen');
-				foreach ($t as &$r) {
-					if (array_key_exists('query', $r)) {
-						$r['query'] = implode(PHP_EOL, $r['query']);
-					}
-					$r = implode(PHP_EOL, $r);
-				}
-				$t = implode(PHP_EOL . PHP_EOL, $t);
-			}
-			$rules = implode(PHP_EOL . PHP_EOL, $rules);
-		}
-	}
-}else{
-	$_POST['desc_comments'] = 1;
-	$_POST['tabbed_rewrites'] = "http://www.test.com/test.html	http://www.test.com/spiders.html" . PHP_EOL . "http://www.test.com/faq.html?faq=13&layout=bob	http://www.test2.com/faqs.html" . PHP_EOL . "text/faq.html?faq=20	helpdesk/kb.php";
-}
-
+if (!$rules = $ruleGen->getRules())
+	$ruleGen->setDemoData();
 ?>
 <form method="post" class="htaccess-rewrites">
-	<textarea cols="100" rows="20" name="tabbed_rewrites" class="rewrite-field tabbed"><?php echo htmlentities( $_POST['tabbed_rewrites'] ) ?></textarea><br />
-	<select name="type" class="method">
-		<option>301</option>
+    <textarea cols="100" rows="20" name="tabbed_rewrites" class="rewrite-field tabbed"><?php echo htmlentities($_POST['tabbed_rewrites']) ?></textarea>
+	<br/>
+    <select name="type" class="method">
+		<option<?php echo $_POST['type'] == '301' ? ' selected="selected"' : '' ?>>301</option>
 		<option<?php echo $_POST['type'] == 'Rewrite' ? ' selected="selected"' : '' ?>>Rewrite</option>
-	</select>
-	<label><input type="checkbox" name="desc_comments" value="1"<?php echo $_POST['desc_comments'] ? ' checked="checked"' : '' ?> class="comments">Comments</label>
-    <label><input type="checkbox" name="always_show_host" value="1"<?php echo $_POST['always_show_host'] ? ' checked="checked"' : '' ?> class="host">Always add {HTTP_HOST} condition (f.i. multi-domain sites)</label>
-	<br />
-	<textarea cols="100" rows="20" readonly="readonly" class="rewrite-field output"><?php echo htmlentities($rules) ?></textarea><br />
-	<input type="submit" />
+    </select>
+    <label><input type="checkbox" name="desc_comments" value="1"<?php echo $_POST['desc_comments'] ? ' checked="checked"' : '' ?> class="comments">Comments</label>
+    <label><input type="checkbox" name="always_show_host" value="1"<?php echo $_POST['always_show_host'] ? ' checked="checked"' : '' ?> class="host">Always add HTTP_HOST (f.i. multi-domain sites)</label>
+    <br/>
+    <textarea cols="100" rows="20" readonly="readonly" class="rewrite-field output"><?php echo htmlentities($rules) ?></textarea><br/>
+    <input type="submit"/>
 </form>

--- a/index.php
+++ b/index.php
@@ -86,14 +86,14 @@ if( $_POST ) {
 }
 
 ?>
-<form method="post">
-	<textarea cols="100" rows="20" name="tabbed_rewrites" style="width: 100%;"><?php echo htmlentities( $_POST['tabbed_rewrites'] ) ?></textarea><br />
-	<select name="type">
+<form method="post" class="htaccess-rewrites">
+	<textarea cols="100" rows="20" name="tabbed_rewrites" class="rewrite-field tabbed"><?php echo htmlentities( $_POST['tabbed_rewrites'] ) ?></textarea><br />
+	<select name="type" class="method">
 		<option>301</option>
 		<option<?php echo $_POST['type'] == 'Rewrite' ? ' selected="selected"' : '' ?>>Rewrite</option>
 	</select>
-	<label><input type="checkbox" name="desc_comments" value="1"<?php echo $_POST['desc_comments'] ? ' checked="checked"' : '' ?>>Comments</label>
+	<label><input type="checkbox" name="desc_comments" value="1"<?php echo $_POST['desc_comments'] ? ' checked="checked"' : '' ?> class="comments">Comments</label>
 	<br />
-	<textarea cols="100" rows="20" readonly="readonly" style="width: 100%;"><?php echo htmlentities($rules) ?></textarea><br />
-	<center><input type="submit" /></center>
+	<textarea cols="100" rows="20" readonly="readonly" class="rewrite-field output"><?php echo htmlentities($rules) ?></textarea><br />
+	<input type="submit" />
 </form>


### PR DESCRIPTION
Hello Jesse Donat,

I've updated your mod_rewrite rule generator. It now takes the types of rules into account and there is an option to force the HTTP_HOST condition to appear. This comes in handy if you have one virtual host listening to multiple domain names.

These types are:
- 0: comment
- 1: a rule, a host and query string(s)
- 2: a rule and query string(s) no host
- 3: a rule, a host, no query string
- 4: just a rule, no host, no query string

Rules will appear in the output in this order. This way a rule without query strings cannot overrule the same rule with query strings.

Rules with the most query strings will be placed over those with less query strings

I've used your script a dozen times and with these adaptions it could save a lot of people a lot of time, while it stays simple and small.

Please have a look at my update and, if you like it, please pull it into your repo.